### PR TITLE
Ensure thread cycles return post ID when no comments

### DIFF
--- a/app/orchestrator/post_cycle.py
+++ b/app/orchestrator/post_cycle.py
@@ -51,7 +51,7 @@ def run_thread_cycle(
     comments = generator.generate_thread_comments(topic, main_post_content, recipe)
     if not comments:
         logger.warning("No comments were generated for the thread. Cycle ends.")
-        return
+        return post_id
 
     # 4. Publish comments with staggered delays
     min_delay, max_delay = comments_style.get("stagger_seconds", [60, 180])

--- a/tests/orchestrator/test_post_cycle.py
+++ b/tests/orchestrator/test_post_cycle.py
@@ -1,4 +1,6 @@
 import pytest
+from unittest import mock
+
 from app.orchestrator import post_cycle
 
 # A sample recipe for a longform post
@@ -11,6 +13,12 @@ THREAD_RECIPE = {
     "post_style": {"length_words": [5, 10], "tone": "engaging", "cta": "Read more below!"},
     "comments_style": {"count": 2, "length_words": [5, 10], "stagger_seconds": [1, 2]},
 }
+
+@pytest.fixture
+def mocker():
+    """Provides access to unittest.mock for compatibility with pytest-mock usage."""
+    return mock
+
 
 @pytest.fixture
 def mock_generator(mocker):
@@ -100,6 +108,28 @@ def test_run_thread_cycle_success(mocker, mock_generator, mock_fb_client, mock_p
     assert mock_fb_client.add_comment.call_count == 2
     mock_fb_client.add_comment.assert_any_call(post_id, comments[0])
     mock_fb_client.add_comment.assert_any_call(post_id, comments[1])
+
+
+def test_run_thread_cycle_returns_post_id_when_no_comments(
+    mocker, mock_generator, mock_fb_client, mock_protocol_enforcer
+):
+    """Ensures cycles without generated comments still return the post ID."""
+    mocker.patch("time.sleep")
+    topic = "thread topic"
+    main_post_content = "Main post."
+    post_id = "fb_post_456"
+
+    mock_generator.generate_post.return_value = main_post_content
+    mock_generator.generate_thread_comments.return_value = []
+    mock_fb_client.post_to_feed.return_value = post_id
+    mock_protocol_enforcer.validate_content.return_value = True
+
+    result = post_cycle.run_thread_cycle(
+        topic, mock_generator, mock_fb_client, mock_protocol_enforcer, THREAD_RECIPE
+    )
+
+    assert result == post_id
+    mock_fb_client.add_comment.assert_not_called()
 
 def test_run_thread_cycle_post_fails(mock_generator, mock_fb_client, mock_protocol_enforcer):
     """Tests that the thread cycle aborts if the main post fails."""


### PR DESCRIPTION
## Summary
- ensure `run_thread_cycle` returns the published post ID even when no thread comments are generated
- add a regression test covering the empty comment scenario and provide a local `mocker` fixture for unit tests

## Testing
- `FACEBOOK_PAGE_ID=1 FACEBOOK_USER_ACCESS_TOKEN=token OPENAI_API_KEY=key pytest tests/orchestrator/test_post_cycle.py`


------
https://chatgpt.com/codex/tasks/task_e_68d6784aff74832e957727c88354f182

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected handling when no thread comments are generated, preserving the original post reference and preventing creation of empty or placeholder comments. This improves consistency and avoids confusing, comment-less updates.

* **Tests**
  * Added coverage for the no-comment scenario and the successful thread flow, ensuring expected outcomes.
  * Improved test reliability with updated mocking compatibility to reduce flaky behavior across environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->